### PR TITLE
Fixed PunkText's scaledWidth/Height mismatching accessor types (uint -> Number)

### DIFF
--- a/src/punk/ui/PunkText.as
+++ b/src/punk/ui/PunkText.as
@@ -302,12 +302,12 @@ package punk.ui
 		/**
 		 * The scaled width of the text image.
 		 */
-		override public function get scaledWidth():uint { return _width * scaleX * scale; }
+		override public function get scaledWidth():Number { return _width * scaleX * scale; }
 		
 		/**
 		 * The scaled height of the text image.
 		 */
-		override public function get scaledHeight():uint { return _height * scaleY * scale; }
+		override public function get scaledHeight():Number { return _height * scaleY * scale; }
 		
 		/**
 		 * Width of the text within the image.


### PR DESCRIPTION
Fixed PunkText's scaledWidth() and scaledHeight() mismatching accessor types (Image uses Number, PunkText was using uint). This prevents compilation (AIR SDK 3.9.0.1030).

Screenshot: https://www.dropbox.com/s/jbz409etlywsp5x/Screenshot%202014-07-06%2023.55.45.png
