### PR TITLE
Change return type for overrides in PunkText.as

### DIFF
--- a/src/punk/ui/PunkText.as
+++ b/src/punk/ui/PunkText.as
@@ -302,12 +302,12 @@ package punk.ui
 		/**
 		 * The scaled width of the text image.
 		 */
-		override public function get scaledWidth():uint { return _width * scaleX * scale; }
+		override public function get scaledWidth():Number { return _width * scaleX * scale; }
 		
 		/**
 		 * The scaled height of the text image.
 		 */
-		override public function get scaledHeight():uint { return _height * scaleY * scale; }
+		override public function get scaledHeight():Number { return _height * scaleY * scale; }
 		
 		/**
 		 * Width of the text within the image.


### PR DESCRIPTION
Change the return types of the scaledWidth() and scaledHeight() override functions in PunkText.as to be Number instead of uint. This allows for compatibility with FlashPunk 1.7.2 Jet Cougar.